### PR TITLE
Rewrite API to select heuristics via dispatch

### DIFF
--- a/src/TimingDebug.jl
+++ b/src/TimingDebug.jl
@@ -10,6 +10,6 @@ include("objectives.jl")
 export F₁, F₂, F₃
 
 include("optimization.jl")
-export adjust_periods, LocalSearch
+export adjust_periods, LocalSearch, ExhaustiveSearch
 
 end # module TimingDebug

--- a/src/TimingDebug.jl
+++ b/src/TimingDebug.jl
@@ -10,6 +10,6 @@ include("objectives.jl")
 export F₁, F₂, F₃
 
 include("optimization.jl")
-export optimal_timing_debugging
+export adjust_periods, LocalSearch
 
 end # module TimingDebug

--- a/src/optimization.jl
+++ b/src/optimization.jl
@@ -68,3 +68,18 @@ function _adjust_periods(objective::Function, T::Vector{TaskSet}, ::LocalSearchA
     end
     argmin(Ωⱼ -> Ωⱼ.F, Ω).P
 end
+
+
+struct ExhaustiveSearchAlg <: PeriodAdjustmentAlgorithm end
+
+"""
+    ExhaustiveSearch
+
+Use an exhaustive search to optimally adjust periods over the assignments specified
+by an iterator `itr`.
+"""
+const ExhaustiveSearch = ExhaustiveSearchAlg()
+
+function _adjust_periods(objective::Function, T::Vector{TaskSet}, ::ExhaustiveSearchAlg; itr)
+    argmin(P -> objective(T, P), itr)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,8 @@
 using Test
-using TimingDebug: optimal_timing_debugging, F₁, F₂, F₃
+using TimingDebug: adjust_periods, F₁, F₂, F₃
 
 include("tasks.jl")
 
-@test optimal_timing_debugging(F₁, τ) ≈ [ 25e-3,  10e-3, 105e-3,  30e-3,  40e-3] atol=1e-5
-@test optimal_timing_debugging(F₂, τ) ≈ [ 15e-3,  15e-3,  70e-3,  85e-3,  25e-3] atol=1e-5
-@test optimal_timing_debugging(F₃, τ) ≈ [ 20e-3,  15e-3,  75e-3,  30e-3,  35e-3] atol=1e-5
+@test adjust_periods(F₁, τ) ≈ [ 25e-3,  10e-3, 105e-3,  30e-3,  40e-3] atol=1e-5
+@test adjust_periods(F₂, τ) ≈ [ 15e-3,  15e-3,  70e-3,  85e-3,  25e-3] atol=1e-5
+@test adjust_periods(F₃, τ) ≈ [ 20e-3,  15e-3,  75e-3,  30e-3,  35e-3] atol=1e-5


### PR DESCRIPTION
This PR replaces our old `optimal_timing_debugging` function with a shiny new `adjust_periods` API.  The user-facing function takes a new `alg` parameter of an abstract type, whose concrete children specify the heuristic to use for period adjustment.  This PR adds and exhaustive search alongside the existing heuristic, and as such, we provide two concrete children.

* `LocalSearch` specifies the existing logic of `optimal_timing_debugging`, implementing the approach from our previous paper.
* `ExhaustiveSearch` specifies an exhaustive search over a given iterator of period assignments.